### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ name: CI
 
 on: [ push ]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/alexander-scott/homelab/security/code-scanning/1](https://github.com/alexander-scott/homelab/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the provided steps, the workflow primarily checks out the repository, sets up Python, and runs a pre-commit action. These tasks only require read access to the repository contents. Therefore, we will set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
